### PR TITLE
commit_linter.py: do not check for word "closes" keyword in PR message.

### DIFF
--- a/code/commit_linter.py
+++ b/code/commit_linter.py
@@ -22,7 +22,6 @@ URL_REGEX = re.compile(
     re.IGNORECASE,
 )
 LINKED_ISSUES_REGEX = re.compile(
-    r"(?:(?:close|resolve)[sd]?|fix|fixe[sd])\s+"
     r"(?:(?:(?P<owner1>[a-z0-9-_]+)\/(?P<repo1>[a-z0-9-_]+))?"
     r"#|https:\/\/github\.com\/"
     r"(?P<owner2>[a-z0-9-_]+)\/(?P<repo2>[a-z0-9-_]+)\/issues\/)(?P<number>\d+)",


### PR DESCRIPTION
We still should be linking to an issue but we do not necessarily need to be closing an issue in every single PR.